### PR TITLE
Prevent CLI from throwing errors altogether.

### DIFF
--- a/lib/commandLine.js
+++ b/lib/commandLine.js
@@ -204,9 +204,13 @@ socket.data("done", function(data){
 
 
 // if master is not running
-socket.on("error", function(err){
-	if (err.code === "ECONNREFUSED") console.log("Connection refused. Is the master running?".red);
-	else throw err;
+socket.on("error", function(err) {
+	if (err.code === "ECONNREFUSED") {
+		console.log("Connection refused. Is the master running?".red);
+	}	else {
+		console.log(err);
+		process.exit(1);
+	}
 });
 
 var start = exports.start = function(options){

--- a/test/cli.js
+++ b/test/cli.js
@@ -5,11 +5,11 @@ describe("cli", function(){
 	describe("require", function(){
 
 		// will not throw anyway because there are not enough paramters
-		it.skip("should NOT throw if master is not running", function(){
+		it("should NOT throw if master is not running", function(){
 			// command line tools should not *throw* for simple stuff like that (?)
 			(function(){
 				require("../cli");
-			}).should.not.throw(/not running/);
+			}).should.not.throw();
 		});
 
 	});


### PR DESCRIPTION
The issue I was having was that if I ran `node server.js status`, I would get
this error:

```
./node_modules/clu/lib/commandLine.js:209
    else throw err;
               ^
Error: connect ENOENT
    at errnoException (net.js:901:11)
    at Object.afterConnect [as oncomplete] (net.js:892:19)
```

I haven't been able to figure out how to directly execute the status command,
and thus, haven't been able to add a proper test.  Any help here would be
greatly appreciated.
